### PR TITLE
Enhance CLI with metadata options

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,21 @@
+# VMTP CLI
+
+This directory contains a small command line utility for sending VMTP messages
+to the example Cloudflare Worker included in this repository.
+
+## Usage
+
+```bash
+node index.js [options] <recipient...> <body>
+```
+
+### Options
+
+- `--worker <url>`: URL of the worker endpoint. Defaults to `http://localhost:8787`.
+- `--subject <subject>`: Subject line of the message. Defaults to `VMTP Test`.
+- `--sender <address>`: Sender address. Defaults to `noreply@example.com`.
+- `--metadata <key=value>`: Metadata pairs to attach to the message. May be
+  specified multiple times.
+- `--metadata-file <path>`: Path to a JSON file whose key/value pairs will be
+  merged into the metadata object.
+```

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { program } from 'commander';
+import { readFileSync } from 'fs';
 import { sendMessage } from '../client/index.js';
 
 program
@@ -7,15 +8,37 @@ program
   .argument('<body>', 'message body')
   .option('--worker <url>', 'worker URL', 'http://localhost:8787')
   .option('--subject <subject>', 'message subject', 'VMTP Test')
-  .option('--sender <address>', 'sender address', 'noreply@example.com');
+  .option('--sender <address>', 'sender address', 'noreply@example.com')
+  .option('--metadata <pair...>', 'metadata key=value pairs')
+  .option('--metadata-file <path>', 'JSON file containing metadata');
 
 program.parse();
 const opts = program.opts();
 const args = program.args;
 const recipients = args.slice(0, args.length - 1);
 const body = args[args.length - 1];
+const metadata = {};
+if (opts.metadata) {
+  const pairs = Array.isArray(opts.metadata) ? opts.metadata : [opts.metadata];
+  for (const pair of pairs) {
+    const [key, value] = pair.split('=');
+    if (key && value !== undefined) {
+      metadata[key] = value;
+    }
+  }
+}
 
-sendMessage(opts.worker, opts.sender, recipients, opts.subject, body)
+if (opts.metadataFile) {
+  try {
+    const contents = readFileSync(opts.metadataFile, 'utf8');
+    Object.assign(metadata, JSON.parse(contents));
+  } catch (err) {
+    console.error(`Failed to read metadata file: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+sendMessage(opts.worker, opts.sender, recipients, opts.subject, body, metadata)
   .then((r) => {
     console.log(r);
   })


### PR DESCRIPTION
## Summary
- allow sending metadata key/value pairs or a JSON file
- document CLI usage and options

## Testing
- `npm test` *(fails: Missing script)*