### PR TITLE
Enhance VMTP with attachments and batch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ The client can send a VMTP message using:
 python -m vmtp.client recipient@example.com "Hello from VMTP"
 ```
 
+Attachments and metadata can be included using the CLI options:
+
+```bash
+python -m vmtp.client --attach example.txt --metadata key=value \
+    recipient@example.com "With extras"
+```
+
 When running against a standard SMTP server, the client will automatically fall back to SMTP.
 
 ## Cloudflare Worker
@@ -55,6 +62,17 @@ Once deployed, you can send a message using the provided CLI:
 ```bash
 node cli/index.js --worker https://your-worker.example.workers.dev \
     recipient@example.com "Hello from VMTP via Worker"
+# send with an attachment
+node cli/index.js --worker https://your-worker.example.workers.dev \
+    --attach ./file.txt recipient@example.com "With attachment"
+```
+
+The worker also exposes a `/batch` endpoint that accepts an array of messages:
+
+```bash
+curl -X POST https://your-worker.example.workers.dev/batch \
+     -H 'Content-Type: application/json' \
+     -d '{"messages":[{"sender":"a@example.com","recipients":["b@example.com"],"subject":"test","body":"hi"}]}'
 ```
 
 

--- a/vmtp/server.py
+++ b/vmtp/server.py
@@ -2,6 +2,7 @@
 
 import asyncore
 import smtpd
+from email import message_from_bytes
 
 
 class VMTPServer(smtpd.SMTPServer):
@@ -13,7 +14,14 @@ class VMTPServer(smtpd.SMTPServer):
 
     def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         print(f"Received message from {mailfrom} to {rcpttos}")
-        print(data)
+        msg = message_from_bytes(data)
+        if msg.is_multipart():
+            for part in msg.iter_attachments():
+                print(
+                    f"Attachment: {part.get_filename()} ({part.get_content_type()})"
+                )
+        else:
+            print(msg.get_payload())
         return None  # accept the message
 
     # Advertise VMTP during EHLO


### PR DESCRIPTION
## Summary
- add CLI option to attach files
- support attachments in the Python VMTP client and server
- implement attachment storing and batch sending in the Cloudflare Worker
- document new CLI options and worker batch endpoint

## Testing
- `python -m py_compile vmtp/*.py`
- `node --check worker/index.js`
- `node --check cli/index.js`
- `node --check client/index.js`
